### PR TITLE
Set locale for unrar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM ubuntu:trusty
 MAINTAINER Patrick Oberdorf "patrick@oberdorf.net"
 
+# Set the locale
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
 RUN echo "deb http://archive.ubuntu.com/ubuntu/ trusty-security multiverse" >> /etc/apt/sources.list
 RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ trusty-security multiverse" >> /etc/apt/sources.list
 


### PR DESCRIPTION
This is a importen change for the unpacker (unrar)

Without custom locales fails the unrar when the file name has umlauts.

Currently:
`unrar helloäöü.rar` -> fail

My PR:
`unrar helloäöü.rar` -> works

for branch: master and release/v0.4.9
