### PR TITLE
Add UID/GID configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y python \
 	python-django \
 	git \
 	rhino \
+	gosu \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 	&& pip install Send2Trash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ If you want to have your configuration persistent you have to link the configura
 ```sh
 docker run -d -v <host directoy>:/opt/pyload/pyload-config -P writl/pyload:latest
 ```
+
+By default, pyload will be run as root, and will download files with uid 0 and gid 0. If you want to change this behavior, you can specify the UID and GID that will be used for the downloaded files by using ENV VARS
+
+```sh
+docker \
+    run \
+    -d \
+    -v <host download directory>:/opt/pyload/Downloads \
+    -v <host config directoy>:/opt/pyload/pyload-config \
+    -e UID=<uid> \
+    -e GID=<gid> \
+    -P \
+    writl/pyload:latest
+```
+
 Finally
 ----
 After the docker has created you can login via the webinterface with:

--- a/run.sh
+++ b/run.sh
@@ -13,4 +13,16 @@ then
         rm /opt/pyload/pyload-config/pyload.pid
 fi
 
-exec /opt/pyload/pyLoadCore.py
+[ -z "$UID" ] && UID=0
+[ -z "$GID" ] && GID=0
+
+# Appending a line at the end of /etc/passwd /etc/group is safer
+# than using adduser because if UID and GID are already present,
+# adduser will fail while this will work as expected.
+echo -e "appuser:x:${UID}:${GID}:appuser:/app:/bin/false\n" >> /etc/passwd
+echo -e "appgroup:x:${GID}:appuser\n" >> /etc/group
+
+chown -R appuser:appgroup /opt/pyload
+
+exec gosu appuser python /opt/pyload/pyLoadCore.py
+


### PR DESCRIPTION
**The problem**:
Once the container as started downloading files, the files downloaded all have UID 0 and GID 0 because pyload is started as root in the container.

Sometimes you may want the files to have the uid/gid of a certain user.

**The solution provided in this PR**:
- UID/GID may be provided as env var.
- The starting script will create a new user with this UID/GID (or with 0/0 if none is provided, acting as root thus no perceptible difference from current container)
- The starting script will start pyload as this user (making sure pyload will still have PID 1 in order to keep all signal sent to the container forwarded to the pyload process, thus using both `exec` and `gosu`)

**Side effect**:
- All files in the download directory will be chown to `<uid>:<gid>`