### PR TITLE
Expose additional ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ ADD run.sh /run.sh
 RUN chmod +x /run.sh
 
 EXPOSE 8000
+EXPOSE 9666
+EXPOSE 7227
 VOLUME /opt/pyload/pyload-config
 VOLUME /opt/pyload/Downloads
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       container_name: pyload
       ports:
         - 8000:8000
+        - 9666:9666
+        - 7227:7227
       environment:
         - UID=1000
         - GID=1000


### PR DESCRIPTION
Port 9666 allows for click'n'load
Port 7227 alloes for remote control e.g. via https://github.com/pyload/pyload-android