### PR TITLE
ExtractArchive - SevenZip missing / Release/v0.4.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:bionic
 MAINTAINER Patrick Oberdorf "patrick@oberdorf.net"
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV VERSION=0.4.20
 
 RUN apt-get update && apt-get install -y python \
 	locales \
@@ -37,7 +38,7 @@ ENV LC_ALL en_US.UTF-8
 
 RUN git clone https://github.com/pyload/pyload.git /opt/pyload \
         && cd /opt/pyload \
-        && git checkout stable \
+        && git checkout $VERSION \
         && echo "/opt/pyload/pyload-config" > /opt/pyload/module/config/configdir
 
 ADD pyload-config/ /tmp/pyload-config

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Install
 Install is easy as all docker images
 
 ```sh
-docker pull writl/pyload:latest
+docker pull writl/pyload:0.4.20
 ```
 
 Running
 ----
 
 ```sh
-docker run -d -P writl/pyload:latest
+docker run -d -P writl/pyload:0.4.20
 ```
 
 Configuration
@@ -34,17 +34,17 @@ Configuration
 You can link your Downloads to your host very easy like that:
 
 ```sh
-docker run -d -v <host directoy>:/opt/pyload/Downloads -P writl/pyload:latest
+docker run -d -v <host directoy>:/opt/pyload/Downloads -P writl/pyload:0.4.20
 ```
 Notice to replace ```<host directory>``` with your directory path on the host. So if you want to store your Downloads in ```/tmp/Downloads``` then your command would look like this:
 
 ```sh
-docker run -d -v /tmp/Downloads:/opt/pyload/Downloads -P writl/pyload:latest
+docker run -d -v /tmp/Downloads:/opt/pyload/Downloads -P writl/pyload:0.4.20
 ```
 If you want to have your configuration persistent you have to link the configuration directory outside of the container. This can happen like this:
 
 ```sh
-docker run -d -v <host directoy>:/opt/pyload/pyload-config -P writl/pyload:latest
+docker run -d -v <host directoy>:/opt/pyload/pyload-config -P writl/pyload:0.4.20
 ```
 
 By default, pyload will be run as root, and will download files with uid 0 and gid 0. If you want to change this behavior, you can specify the UID and GID that will be used for the downloaded files by using ENV VARS
@@ -60,7 +60,7 @@ docker \
     -e UID=<uid> \
     -e GID=<gid> \
     -P \
-    writl/pyload:latest
+    writl/pyload:0.4.20
 ```
 Sample compose file
 -----
@@ -68,7 +68,7 @@ Sample compose file
 version: "2"
 services:
     pyload:
-      image: writl/pyload:latest
+      image: writl/pyload:0.4.20
       container_name: pyload
       ports:
         - 8000:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
     pyload:
-      image: writl/pyload:latest
+      image: writl/pyload:0.4.20
       container_name: pyload
       ports:
         - 8000:8000


### PR DESCRIPTION
After the friendly support of a pyload developer:

[https://github.com/pyload/pyload/issues/3872](url)

Is there a way to add "SevenZip" to an update so that folders can be excluded after extracting a file (and not just individual files)? I mean this function: "Don't extract the following files:".

`DEBUG	ADDON ExtractArchive: Found HjSplit 0.02 | Found UnRar 5.50 | Found UnZip 2.7.17 | Found UnTar 2.7.17`